### PR TITLE
Mirror of facebook fresco PR IssueNumber 2552

### DIFF
--- a/imagepipeline-base/src/main/java/com/facebook/imagepipeline/transcoder/DownsampleUtil.java
+++ b/imagepipeline-base/src/main/java/com/facebook/imagepipeline/transcoder/DownsampleUtil.java
@@ -15,6 +15,7 @@ import com.facebook.imagepipeline.common.ResizeOptions;
 import com.facebook.imagepipeline.common.RotationOptions;
 import com.facebook.imagepipeline.image.EncodedImage;
 import com.facebook.infer.annotation.Nullsafe;
+import java.text.DecimalFormat;
 import javax.annotation.Nullable;
 
 @Nullsafe(Nullsafe.Mode.STRICT)
@@ -102,17 +103,22 @@ public class DownsampleUtil {
     final float widthRatio = ((float) resizeOptions.width) / widthAfterRotation;
     final float heightRatio = ((float) resizeOptions.height) / heightAfterRotation;
     float ratio = Math.max(widthRatio, heightRatio);
+
+    // Format float values for the log message in advance
+    // due to possible String.Format() NPE within FLog.formatString() in some OS
+    final DecimalFormat dimensionsFormatter = new DecimalFormat("#.#");
+    final DecimalFormat ratioFormatter = new DecimalFormat("#.###");
     FLog.v(
         "DownsampleUtil",
         "Downsample - Specified size: %dx%d, image size: %dx%d "
-            + "ratio: %.1f x %.1f, ratio: %.3f",
+            + "ratio: %s x %s, ratio: %s",
         resizeOptions.width,
         resizeOptions.height,
         widthAfterRotation,
         heightAfterRotation,
-        widthRatio,
-        heightRatio,
-        ratio);
+        dimensionsFormatter.format(widthRatio),
+        dimensionsFormatter.format(heightRatio),
+        ratioFormatter.format(ratio));
     return ratio;
   }
 


### PR DESCRIPTION
Mirror of facebook fresco PR IssueNumber 2552
 Motivation (required)

Closes (https://github.com/facebook/fresco/issues/2504)
Details on the fix (https://github.com/facebook/fresco/issues/2504issuecomment-657771489)

This PR fixes the local problem only. I believe it would be better to preformat float values in strings within `Flog.formatString()` by using `DecimalFormat`. However, in that case, it would increase complexity since it'd require placeholders parsing.

 Test Plan (required)

Since the logic hasn't changed, I believe using existing tests is enough. Due to the fact that the problem occurs on an unknown list of OS, I wasn't able to find an edge case to create a test.
